### PR TITLE
Fix Notification without Large Icon Error in NotificationListener.java

### DIFF
--- a/android/src/main/java/notification/listener/service/NotificationListener.java
+++ b/android/src/main/java/notification/listener/service/NotificationListener.java
@@ -106,8 +106,17 @@ public class NotificationListener extends NotificationListenerService {
             if (largeIcon == null) {
                 return null;
             }
+
             Drawable iconDrawable = largeIcon.loadDrawable(context);
-            Bitmap iconBitmap = ((BitmapDrawable) iconDrawable).getBitmap();
+            if (iconDrawable == null) {
+                return null;
+            }
+
+            Bitmap iconBitmap = getBitmapFromDrawable(iconDrawable);
+            if (iconBitmap == null) {
+                return null;
+            }
+            
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             iconBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
 


### PR DESCRIPTION
Reproduce:
Create emulator: Pixel 4 API 29
wait `Android Setup` (com.google.android.setupwizard) notification appeared, after that just wait several minutes until for `Android Setup` repeated notification happened
<img width="589" height="468" alt="2025-07-14 22_55_52-Window" src="https://github.com/user-attachments/assets/cd0f0477-118f-4e85-aec6-ed87959e7504" />
